### PR TITLE
fix: compilation fails if basedir resolves to cwd

### DIFF
--- a/src/patch/lib/createProgram.ts
+++ b/src/patch/lib/createProgram.ts
@@ -37,7 +37,7 @@ function getProjectConfig(compilerOptions: TS.CompilerOptions, rootFileNames: Re
   let projectDir = getProjectDir(compilerOptions);
 
   if (configFilePath === undefined) {
-    const baseDir = (rootFileNames.length > 0) ? dirname(rootFileNames[0]) : projectDir ?? process.cwd;
+    const baseDir = (rootFileNames.length > 0) ? dirname(rootFileNames[0]) : projectDir ?? process.cwd();
     configFilePath = ts.findConfigFile(baseDir, ts.sys.fileExists);
 
     if (configFilePath) {


### PR DESCRIPTION
Process.cwd missed the function call resulting in compilation error when baseDir resolved to process.cwd.
TS version: 4.3.5