### PR TITLE
change compilation target of CLI and patch to match TS's ES2018

### DIFF
--- a/projects/patch/tsconfig.json
+++ b/projects/patch/tsconfig.json
@@ -14,8 +14,8 @@
     "allowSyntheticDefaultImports": true,
     "stripInternal": true,
 
-    "target": "ES5",
-    "lib": [ "es2015", "es5" ],
+    "lib": [ "es2018" ],
+    "target": "ES2018",
     "downlevelIteration": true,
     "useUnknownInCatchVariables": false,
     "newLine": "LF",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,9 +7,9 @@
     "forceConsistentCasingInFileNames": true,
     "useUnknownInCatchVariables": false,
 
-    "lib": [ "es2019" ],
+    "lib": [ "es2018" ],
     "outDir": "dist",
-    "target": "ES2022",
+    "target": "ES2018",
     "module": "CommonJS",
     "moduleResolution": "node",
 


### PR DESCRIPTION
While TS 5.0 supports Node.js 12.20+, I've found that `ts-patch` was failing on Node.js 14 due to using too modern syntax.
I think it makes sense to target ES2018 for both the patch and the CLI, which is the same target that TS now has.

Not sure how we can test Node 14 here, since ts-patch depends on an incompatible older version of itself.