### PR TITLE
fix: support circular `require()` in compiled JS files

### DIFF
--- a/projects/patch/src/plugin/resolve-factory.ts
+++ b/projects/patch/src/plugin/resolve-factory.ts
@@ -179,8 +179,17 @@ namespace tsp {
         const filePath = Module._resolveFilename(request, this);
         const extension = path.extname(filePath);
 
-        /* Pass through for unsupported extensions */
-        if (!supportedExtensions.includes(extension)) return originalRequire.call(this, request);
+        /*
+          Default to the original require for
+          - unsupported extensions
+          - and compiled CJS files to support circular requires
+         */
+        if (
+          (!isEsm && /^\.c?js/.test(extension)) ||
+          !supportedExtensions.includes(extension)
+        ) {
+          return originalRequire.call(this, request);
+        }
 
         /* Load Code */
         const cacheKey = getCachePath(filePath);


### PR DESCRIPTION
This PR fixes the reported stack overflow which seems to happen when there's an import cycle.
The default node `require` algorithm seems to have no issue with this, so we can shortcut to it when importing a non-ESM `.[c]js` file.