### PR TITLE
Update plugin-creator.ts

### DIFF
--- a/projects/patch/src/plugin/plugin-creator.ts
+++ b/projects/patch/src/plugin/plugin-creator.ts
@@ -100,8 +100,6 @@ namespace tsp {
         }
       } finally {
         unhookRequire();
-        const err = new Error();
-        console.log(err.stack);
       }
 
       return res;


### PR DESCRIPTION
Remove logging of every wrapped fn with error stack that isnt an error.

This fixes the looping

```
Error
    at tspWrappedFactory (evalmachine.<anonymous>:350:33)
```

which if ignored, things do seem to work