### PR TITLE
fix: Lock file deletion check

### DIFF
--- a/projects/core/src/utils/file-utils.ts
+++ b/projects/core/src/utils/file-utils.ts
@@ -77,7 +77,7 @@ export function withFileLock<T>(filePath: string, fn: () => T): T {
     fs.writeFileSync(lockFilePath, '');
     return fn();
   } finally {
-    fs.unlinkSync(lockFilePath);
+    if (fs.existsSync(lockFilePath)) fs.unlinkSync(lockFilePath);
   }
 }
 


### PR DESCRIPTION
`unlinkSync` can fail in case `waitForLockRelease` fails with an error and the lock file is never created.