### PR TITLE
Add typescript language service support for incremental source file parsing

### DIFF
--- a/projects/core/src/patch/transformers/add-original-create-program.ts
+++ b/projects/core/src/patch/transformers/add-original-create-program.ts
@@ -28,6 +28,18 @@ export function addOriginalCreateProgramTransformer(context: ts.TransformationCo
       ) {
         const exportObjectLiteral = node.expression.arguments[1];
         if (ts.isObjectLiteralExpression(exportObjectLiteral)) {
+          const originalParseSourceFile = factory.createPropertyAssignment(
+            "originalParseSourceFile",
+            factory.createArrowFunction(
+              undefined,
+              undefined,
+              [],
+              undefined,
+              factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+              factory.createIdentifier("originalParseSourceFile")
+            )
+          );
+
           const originalCreateProgramProperty = factory.createPropertyAssignment(
             "originalCreateProgram",
             factory.createArrowFunction(
@@ -42,7 +54,7 @@ export function addOriginalCreateProgramTransformer(context: ts.TransformationCo
 
           const updatedExportObjectLiteral = factory.updateObjectLiteralExpression(
             exportObjectLiteral,
-            [...exportObjectLiteral.properties, originalCreateProgramProperty]
+            [...exportObjectLiteral.properties, originalCreateProgramProperty, originalParseSourceFile]
           );
 
           const updatedNode = factory.updateExpressionStatement(

--- a/projects/core/src/patch/transformers/sourcefile-parse.ts
+++ b/projects/core/src/patch/transformers/sourcefile-parse.ts
@@ -1,0 +1,111 @@
+import ts from 'typescript';
+
+
+export function patchSourceFile(context: ts.TransformationContext) {
+  const { factory } = context;
+
+
+  return (sourceFile: ts.SourceFile) => {
+
+    const getCompilerOptions = factory.createIdentifier('getCompilerOptions');
+    const res = factory.updateSourceFile(sourceFile, ts.visitNodes(sourceFile.statements, visitNodes) as unknown as ts.Statement[]);
+
+    return res;
+
+    function visitNodes(node: ts.Node): ts.VisitResult<ts.Node> {
+      if (ts.isFunctionDeclaration(node) && node.name && (
+        node.name.escapedText === 'createSourceFile' || node.name.escapedText === 'updateSourceFile2' || node.name.escapedText === 'updateSourceFile'
+      )) {
+        const newParams = factory.createNodeArray([
+          ...node.parameters,
+          factory.createParameterDeclaration(
+            undefined,
+            undefined,
+            getCompilerOptions,
+            undefined,
+            undefined,
+          )])
+
+        return ts.visitEachChild(factory.updateFunctionDeclaration(
+          node,
+          node.modifiers,
+          node.asteriskToken,
+          node.name,
+          node.typeParameters,
+          newParams,
+          node.type,
+          node.body
+        ), visitNodes, context);
+      }
+
+      if (ts.isCallExpression(node) && ((
+        ts.isIdentifier(node.expression) &&
+        node.expression.escapedText === 'createSourceFile'
+      ))) {
+        return factory.updateCallExpression(node, node.expression, node.typeArguments,
+          factory.createNodeArray([...node.arguments, factory.createNull(), getCompilerOptions])
+        );
+      }
+
+      if (
+        ts.isCallExpression(node) && ((
+          ts.isIdentifier(node.expression) &&
+          node.expression.escapedText === 'parseSourceFile'
+        ) || (
+            ts.isPropertyAccessExpression(node.expression) &&
+            ts.isIdentifier(node.expression.expression) &&
+            node.expression.expression.escapedText === 'Parser' &&
+            node.expression.name.escapedText === "parseSourceFile"
+          ))) {
+        return factory.updateCallExpression(node, node.expression, node.typeArguments,
+          factory.createNodeArray([...node.arguments, getCompilerOptions])
+        );
+      }
+      if (ts.isFunctionDeclaration(node) && node.name && node.name.escapedText === 'parseSourceFile') {
+        const originalParseSourceFileId = factory.createIdentifier('originalParseSourceFile');
+        const originalParseSourceFile = factory.updateFunctionDeclaration(
+          node,
+          node.modifiers,
+          node.asteriskToken,
+          originalParseSourceFileId,
+          node.typeParameters,
+          node.parameters,
+          node.type,
+          node.body
+        );
+        const globalAsignment = factory.createAssignment(
+          factory.createPropertyAccessExpression(factory.createIdentifier("globalThis"), originalParseSourceFileId),
+          originalParseSourceFileId
+        )
+
+        const newParseSourceFile = factory.createFunctionDeclaration(
+          undefined,
+          undefined,
+          'parseSourceFile',
+          undefined,
+          [],
+          undefined,
+          factory.createBlock([
+            factory.createReturnStatement(
+              factory.createCallExpression(
+                factory.createPropertyAccessExpression(
+                  factory.createIdentifier('tsp'),
+                  factory.createIdentifier('parseSourceFile')
+                ),
+                undefined,
+                [factory.createSpreadElement(factory.createIdentifier('arguments'))]
+              )
+            ),
+          ])
+        );
+
+        return [newParseSourceFile, originalParseSourceFile, globalAsignment]
+      }
+
+      return ts.visitEachChild(node, visitNodes, context);
+    }
+
+  };
+}
+
+// endregion

--- a/projects/patch/src/ts/create-program.ts
+++ b/projects/patch/src/ts/create-program.ts
@@ -1,16 +1,16 @@
 namespace tsp {
-  const activeProgramTransformers = new Set<string>();
+  export const activeProgramTransformers = new Set<string>();
   const { dirname } = require('path');
 
   /* ********************************************************* */
   // region: Helpers
   /* ********************************************************* */
 
-  function getProjectDir(compilerOptions: tsShim.CompilerOptions) {
+  export function getProjectDir(compilerOptions: tsShim.CompilerOptions) {
     return compilerOptions.configFilePath && dirname(compilerOptions.configFilePath);
   }
 
-  function getProjectConfig(compilerOptions: tsShim.CompilerOptions, rootFileNames: ReadonlyArray<string>) {
+  export function getProjectConfig(compilerOptions: tsShim.CompilerOptions, rootFileNames: ReadonlyArray<string>) {
     let configFilePath = compilerOptions.configFilePath;
     let projectDir = getProjectDir(compilerOptions);
 
@@ -37,7 +37,7 @@ namespace tsp {
     return tsShim.parseJsonConfigFileContent(result.config, tsShim.sys, projectDir, undefined, configFileNamePath);
   }
 
-  function preparePluginsFromCompilerOptions(plugins: any): PluginConfig[] {
+  export function preparePluginsFromCompilerOptions(plugins: any): PluginConfig[] {
     if (!plugins) return [];
 
     // Old transformers system
@@ -83,16 +83,16 @@ namespace tsp {
 
     /* Get Config */
     const projectConfig = getProjectConfig(options, rootNames);
-    if ([ 'tsc', 'tsserver', 'tsserverlibrary' ].includes(tsp.currentLibrary)) {
+    if (['tsc', 'tsserver', 'tsserverlibrary'].includes(tsp.currentLibrary)) {
       options = projectConfig.compilerOptions;
       if (createOpts) createOpts.options = options;
     }
 
     /* Invoke TS createProgram */
     let program: tsShim.Program & { originalEmit?: tsShim.Program['emit'] } =
-      createOpts ?
-      tsShim.originalCreateProgram(createOpts) :
-      tsShim.originalCreateProgram(rootNames, options, host, oldProgram, configFileParsingDiagnostics);
+      createOpts ? // @ts-ignore
+        tsShim.originalCreateProgram(createOpts) : // @ts-ignore
+        tsShim.originalCreateProgram(rootNames, options, host, oldProgram, configFileParsingDiagnostics);
 
     /* Prepare Plugins */
     const plugins = preparePluginsFromCompilerOptions(options.plugins);
@@ -102,7 +102,7 @@ namespace tsp {
     const programTransformers = pluginCreator.getProgramTransformers();
 
     /* Transform Program */
-    for (const [ transformerKey, [ programTransformer, config ] ] of programTransformers) {
+    for (const [transformerKey, [programTransformer, config]] of programTransformers) {
       if (activeProgramTransformers.has(transformerKey)) continue;
       activeProgramTransformers.add(transformerKey);
 

--- a/projects/patch/src/ts/shim.ts
+++ b/projects/patch/src/ts/shim.ts
@@ -34,6 +34,8 @@ namespace tsp {
     export type CompilerHost = import('typescript').CompilerHost;
     export type Diagnostic = import('typescript').Diagnostic;
     export type SourceFile = import('typescript').SourceFile;
+    export type ScriptKind = import('typescript').ScriptKind;
+    export type ScriptTarget = import('typescript').ScriptTarget;
     export type WriteFileCallback = import('typescript').WriteFileCallback;
     export type CancellationToken = import('typescript').CancellationToken;
     export type CustomTransformers = import('typescript').CustomTransformers;

--- a/projects/patch/src/ts/source-file.ts
+++ b/projects/patch/src/ts/source-file.ts
@@ -1,0 +1,38 @@
+
+namespace tsp {
+
+	/* ********************************************************* *
+	 * Patched parseSourceFile()
+	 * ********************************************************* */
+
+	export function parseSourceFile(
+		fileName: string,
+		sourceText: string,
+		languageVersion: tsShim.ScriptTarget,
+		syntaxCursor: never | undefined,
+		setParentNodes = false,
+		scriptKind: tsShim.ScriptKind | undefined,
+		setExternalModuleIndicatorOverride: ((file: tsShim.SourceFile) => void) | undefined,
+		getCompilerOptions: () => tsShim.CompilerOptions
+	): tsShim.SourceFile {
+		const options = getCompilerOptions();
+		const projectDir = getProjectDir(options)
+		/* Get Config */
+
+		/* Invoke TS createProgram */
+		// @ts-ignore
+		let file: tsShim.SourceFile = tsShim.originalParseSourceFile(fileName, sourceText, languageVersion, syntaxCursor, setParentNodes, scriptKind, setExternalModuleIndicatorOverride)
+
+		// /* Prepare Plugins */
+		const plugins = preparePluginsFromCompilerOptions(options.plugins);
+		const pluginCreator = new PluginCreator(plugins, projectDir ?? process.cwd());
+
+		/* Prevent recursion in Program transformers */
+		const transformers = pluginCreator.createTransformers({ program: new Error("Program not available for single source file") as never })
+
+		const transformed = tsShim.transform(file, transformers.before, options);
+		transformed.dispose();
+
+		return transformed.transformed[0]
+	}
+}


### PR DESCRIPTION
###### Also discussed in #85 #86 #96 and https://github.com/microsoft/TypeScript/issues/51493#issuecomment-1653953011 

## Problem
Currently `ts-patch` patches the createProgram function of the typescript compiler to transform the program.
Additionally it patches the `emit` function of the program to transform emitted files.
The problem is that the Typescript language service creates the program at startup and then adds the files to the program incrementally, resulting in the files not being handled by createProgram/emit.
This leads to an inconsistent state between the `tsc` compiler and the ts language service, since the editor may display errors of the program that would not exist if the program had been transformed before.

## Solution
Additionally to patching the createProgram and emit function, ts-patch also patches the `parseSourceFile` function, which gets called for every single file, after it has been loaded. This way ts-patch ensures that the transformer plugins have transformed the file, before the editor handles it.
Within the patched parseSourceFile function ts-patch loads the plugins of the `tsconfig.json` file and executes them after the file has been parsed by the original `parseSourceFile` function.


I've added a working implementation for this feature, but currently there is no distinction between "source transformer plugins" and "parseSourceFile transformer plugins".
Do you have any suggestions on how to differentiate between the plugins?