### PR TITLE
Try #134 - `defaultJSDocParsingMode` of TypeScript v5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "ts-node": "^10.9.1",
     "ts-patch": "3.0.0",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.3.2"
   },
   "directories": {
     "resources": "./dist/resources"

--- a/projects/core/src/patch/patch-module.ts
+++ b/projects/core/src/patch/patch-module.ts
@@ -96,13 +96,20 @@ export function patchModule(tsModule: TsModule, skipDts: boolean = false): { js:
     printableFooters.push(`tsp.${execTscCmd}();`);
   }
 
-  if (tsModule.moduleName === 'tsc.js') {
-    const tscSection = source.body.find(s => s.sourceText.includes('var defaultJSDocParsingMode = 2'));
+  /* Patch defaultJSDocParsingMode */
+  if (
+    tsModule.moduleName === "tsc.js" &&
+    ((tsModule.majorVer === 5 && tsModule.minorVer >= 3) ||
+      tsModule.majorVer > 5)
+  ) {
+    const tscSection = source.body.find((s) =>
+      s.sourceText.includes("var defaultJSDocParsingMode = 2"),
+    );
     if (tscSection) {
       tscSection.updateSourceText(
         tscSection.sourceText.replace(
-          'var defaultJSDocParsingMode = 2', 
-          'var defaultJSDocParsingMode = 0',
+          "var defaultJSDocParsingMode = 2",
+          "var defaultJSDocParsingMode = 0",
         ),
       );
     }

--- a/projects/core/src/patch/patch-module.ts
+++ b/projects/core/src/patch/patch-module.ts
@@ -96,6 +96,18 @@ export function patchModule(tsModule: TsModule, skipDts: boolean = false): { js:
     printableFooters.push(`tsp.${execTscCmd}();`);
   }
 
+  if (tsModule.moduleName === 'tsc.js') {
+    const tscSection = source.body.find(s => s.sourceText.includes('var defaultJSDocParsingMode = 2'));
+    if (tscSection) {
+      tscSection.updateSourceText(
+        tscSection.sourceText.replace(
+          'var defaultJSDocParsingMode = 2', 
+          'var defaultJSDocParsingMode = 0',
+        ),
+      );
+    }
+  }
+
   /* Print the module */
   const printedJs = printModule();
 

--- a/projects/core/src/patch/patch-module.ts
+++ b/projects/core/src/patch/patch-module.ts
@@ -103,13 +103,13 @@ export function patchModule(tsModule: TsModule, skipDts: boolean = false): { js:
       tsModule.majorVer > 5)
   ) {
     const tscSection = source.body.find((s) =>
-      s.sourceText.includes("var defaultJSDocParsingMode = 2"),
+      s.sourceText.includes(JS_DOC_MODE_FROM),
     );
     if (tscSection) {
       tscSection.updateSourceText(
         tscSection.sourceText.replace(
-          "var defaultJSDocParsingMode = 2",
-          "var defaultJSDocParsingMode = 0",
+          JS_DOC_MODE_FROM,
+          JS_DOC_MODE_TO,
         ),
       );
     }
@@ -212,5 +212,8 @@ export function patchModule(tsModule: TsModule, skipDts: boolean = false): { js:
     baseSection.transform([ transformer ]);
   }
 }
+
+const JS_DOC_MODE_FROM = `var defaultJSDocParsingMode = 2 /* ParseForTypeErrors */`;
+const JS_DOC_MODE_TO = `var defaultJSDocParsingMode = 0 /* ParseAll */`;
 
 // endregion

--- a/yarn.lock
+++ b/yarn.lock
@@ -3137,10 +3137,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^5.0.4:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
-  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
+typescript@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.2.tgz#00d1c7c1c46928c5845c1ee8d0cc2791031d4c43"
+  integrity sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
As I don't know how `ts-patch` author @nonara determines about the `defaultJSDocParsingMode` strategy, and even do not have any idea about the caching logic that can be compatible with before TS 5.2, just send a simple PR that changing `defaultJSDocParsingMode` variable value of `tsc.js` to be zero.

Hope @nonara to determine the `defaultJSDocParsingMode` strategy a little bit faster, and publish the new version of `ts-patch` for the TypeScript v5.3 update of todays. Always thanks for your amazing transformation ecosystem contributions, and wish `ts-patch` and its ecosystem to be much universal.