### PR TITLE
Fix #140 bug, the old typescript version problem

### DIFF
--- a/projects/patch/src/ts/create-program.ts
+++ b/projects/patch/src/ts/create-program.ts
@@ -92,7 +92,7 @@ namespace tsp {
     const plugins = preparePluginsFromCompilerOptions(options.plugins);
     const pluginCreator = new PluginCreator(plugins, { resolveBaseDir: projectConfig.projectDir ?? process.cwd() });
 
-    if (tsp.currentLibrary === 'tsc' && pluginCreator.needsTscJsDocParsing) {
+    if (tsp.currentLibrary === 'tsc' && pluginCreator.needsTscJsDocParsing && tsShim.JSDocParsingMode) {
       host!.jsDocParsingMode = tsShim.JSDocParsingMode.ParseAll;
     }
 

--- a/projects/patch/src/ts/create-program.ts
+++ b/projects/patch/src/ts/create-program.ts
@@ -92,7 +92,8 @@ namespace tsp {
     const plugins = preparePluginsFromCompilerOptions(options.plugins);
     const pluginCreator = new PluginCreator(plugins, { resolveBaseDir: projectConfig.projectDir ?? process.cwd() });
 
-    if (tsp.currentLibrary === 'tsc' && pluginCreator.needsTscJsDocParsing && tsShim.JSDocParsingMode) {
+    /* Handle JSDoc parsing in v5.3+ */
+    if (tsp.currentLibrary === 'tsc' && tsShim.JSDocParsingMode && pluginCreator.needsTscJsDocParsing) {
       host!.jsDocParsingMode = tsShim.JSDocParsingMode.ParseAll;
     }
 


### PR DESCRIPTION
Add checking logic whether `tsShim.JSDocParsingMode`, so that fixes the bug from old TypeScript version.

@nonara Hope `3.1.1` patch, and deprecation of `3.1.0` version.