### PR TITLE
fix: don't break on other plugin definitions

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/projects/patch/src/plugin/plugin-creator.ts
+++ b/projects/patch/src/plugin/plugin-creator.ts
@@ -173,7 +173,9 @@ namespace tsp {
       const { resolveBaseDir } = options;
 
       /* Create plugins */
-      this.plugins = configs.map(config => new TspPlugin(config, { resolveBaseDir }));
+      this.plugins = configs
+        .filter(config => config.transform !== undefined)
+        .map(config => new TspPlugin(config, { resolveBaseDir }));
 
       /* Check if we need to parse all JSDoc comments */
       this.needsTscJsDocParsing = this.plugins.some(plugin => plugin.packageConfig?.tscOptions?.parseAllJsDoc === true);


### PR DESCRIPTION
When using the next ts plugin `tsc` breaks. This was not the case in `3.0.2` and was introduced in `3.1.0` ([15570d0](https://github.com/nonara/ts-patch/commit/15570d05e422dd02635eb3c63dc6b3a036cb543a))