### PR TITLE
Fix slice TypeScript 5.5.2

### DIFF
--- a/projects/core/src/slice/module-slice.ts
+++ b/projects/core/src/slice/module-slice.ts
@@ -3,6 +3,7 @@ import { Position } from '../system';
 import semver from 'semver';
 import { sliceTs54 } from './ts54';
 import { sliceTs55 } from './ts55';
+import { sliceTs552 } from './ts552';
 
 
 /* ****************************************************************************************************************** */
@@ -41,7 +42,11 @@ export function sliceModule(moduleFile: ModuleFile, tsVersion: string) {
     return sliceTs54(moduleFile);
   }
 
-  return sliceTs55(moduleFile);
+  if (semver.lt(baseVersion, '5.5.2')) {
+    return sliceTs55(moduleFile);
+  }
+
+  return sliceTs552(moduleFile);
 }
 
 /** @internal */

--- a/projects/core/src/slice/ts552.ts
+++ b/projects/core/src/slice/ts552.ts
@@ -1,0 +1,80 @@
+import { ModuleFile } from '../module';
+import { ModuleSlice } from './module-slice';
+
+
+/* ****************************************************************************************************************** */
+// region: Utils
+/* ****************************************************************************************************************** */
+
+/**
+ * Slice 5.5.2+
+ */
+export function sliceTs552(moduleFile: ModuleFile): ModuleSlice {
+  let firstSourceFileStart: number;
+  let wrapperStart: number | undefined;
+  let wrapperEnd: number | undefined;
+  let bodyStart: number;
+  let bodyEnd: number;
+  let sourceFileStarts: [ name: string, position: number ][] = [];
+
+  const { content } = moduleFile;
+
+  /* Find Wrapper or First File */
+  let matcher = /^(?:\s*\/\/\s*src\/)|(?:var\s+ts\s*=.+)/gm;
+
+  const firstMatch = matcher.exec(content);
+  if (!firstMatch?.[0]) throw ModuleSlice.createError();
+  let bodyWrapper: undefined | { start: string; end: string } = undefined;
+
+  /* Handle wrapped */
+  if (firstMatch[0].startsWith('var')) {
+    wrapperStart = firstMatch.index;
+    bodyStart = firstMatch.index + firstMatch[0].length + 1;
+
+    /* Find First File */
+    matcher = /^\s*\/\/\s*src\//gm;
+    matcher.lastIndex = wrapperStart;
+
+    const firstFileMatch = matcher.exec(content);
+    if (!firstFileMatch?.[0]) throw ModuleSlice.createError();
+
+    firstSourceFileStart = firstFileMatch.index;
+
+    /* Find Wrapper end */
+    // TODO - We may later want to find a better approach, but this will work for now
+    matcher = /^}\)\({ get exports\(\) { return ts; }.+$/gm;
+    matcher.lastIndex = firstFileMatch.index;
+    const wrapperEndMatch = matcher.exec(content);
+    if (!wrapperEndMatch?.[0]) throw ModuleSlice.createError();
+
+    bodyEnd = wrapperEndMatch.index - 1;
+    wrapperEnd = wrapperEndMatch.index + wrapperEndMatch[0].length;
+
+    bodyWrapper = { start: firstMatch[0], end: wrapperEndMatch[0] };
+  }
+  /* Handle non-wrapped */
+  else {
+    firstSourceFileStart = firstMatch.index;
+    bodyStart = firstMatch.index + firstMatch[0].length;
+    bodyEnd = content.length;
+  }
+
+  /* Get Source File Positions */
+  matcher = /^\s*\/\/\s*(src\/.+)$/gm;
+  matcher.lastIndex = firstSourceFileStart;
+  for (let match = matcher.exec(content); match != null; match = matcher.exec(content)) {
+    sourceFileStarts.push([ match[1], match.index ]);
+  }
+
+  return {
+    moduleFile,
+    firstSourceFileStart,
+    wrapperPos: wrapperStart != null ? { start: wrapperStart, end: wrapperEnd! } : undefined,
+    fileEnd: content.length,
+    bodyPos: { start: bodyStart, end: bodyEnd },
+    sourceFileStarts,
+    bodyWrapper
+  };
+}
+
+// endregion


### PR DESCRIPTION
ts-patch currently doesn't work with TypeScript 5.5.2 because the ending of `lib/typescript.js` has changed slightly.

## [`5.5.1-rc`](https://www.unpkg.com/typescript@5.5.1-rc/lib/typescript.js)
```js
// ...
});
})(typeof module !== "undefined" && module.exports ? module : { exports: ts });
if (typeof module !== "undefined" && module.exports) { ts = module.exports; }
//# sourceMappingURL=typescript.js.map
```

## [`5.5.2`](https://www.unpkg.com/typescript@5.5.2/lib/typescript.js)
```js
// ...
});
})({ get exports() { return ts; }, set exports(v) { ts = v; if (typeof module !== "undefined" && module.exports) { module.exports = v; } } })
//# sourceMappingURL=typescript.js.map
```

---

I copied `ts55.ts` to create `ts552.ts`, and then made the appropriate fix.

## Diff
![image](https://github.com/nonara/ts-patch/assets/9200592/7b37a2f0-cdf2-454d-b5ea-c3720c9f6736)

Fixes #159