### PR TITLE
docs(readme): adds ts-overrides-plugin live example

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,6 @@ export default function (program: ts.Program, pluginConfig: PluginConfig, { ts: 
 
 [`{ transform: "@nestia/core/lib/transform" }`](https://github.com/samchon/nestia)
 
-[`{ transform: "ts-overrides-plugin", transformProgram: true }`](https://github.com/DiFuks/ts-overrides-plugin)
-
 ### Altering Diagnostics
 
 Diagnostics can be altered in a Source Transformer.
@@ -266,6 +264,8 @@ export default function (
 **Live Examples**:
 
 [`{ transform: "@typescript-virtual-barrel/compiler-plugin", transformProgram: true }`](https://github.com/zaguiini/typescript-virtual-barrel)
+
+[`{ transform: "ts-overrides-plugin", transformProgram: true }`](https://github.com/DiFuks/ts-overrides-plugin)
 
 ## Plugin Package Configuration
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ export default function (program: ts.Program, pluginConfig: PluginConfig, { ts: 
 
 [`{ transform: "@nestia/core/lib/transform" }`](https://github.com/samchon/nestia)
 
+[`{ transform: "ts-overrides-plugin", transformProgram: true }`](https://github.com/DiFuks/ts-overrides-plugin)
+
 ### Altering Diagnostics
 
 Diagnostics can be altered in a Source Transformer.


### PR DESCRIPTION
Hello! Thank you so much for your wonderful library. It has greatly helped me and my team in refactoring and transitioning the project from strict: false to strict: true. Thanks to your library, I was able to implement a plugin for overriding the ts config. Would it be possible for you to add a link to my plugin in your readme?