### PR TITLE
Fix #174: support TypeScript v5.7

### DIFF
--- a/projects/core/src/actions/patch.ts
+++ b/projects/core/src/actions/patch.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { getInstallerOptions, InstallerOptions } from '../options';
 import { writeFileWithLock } from '../utils';
 import { getPatchedSource } from '../patch/get-patched-source';
+import { existsSync } from 'fs';
 
 
 /* ****************************************************************************************************************** */
@@ -29,7 +30,10 @@ export function patch(moduleNameOrNames: string | string[], opts?: Partial<Insta
 
   /* Get modules to patch and patch info */
   const moduleFiles: [ string, ModuleFile ][] =
-    targetModuleNames.map(m => [ m, getModuleFile(tsPackage.getModulePath(m)) ]);
+    targetModuleNames
+      .filter(m => existsSync(tsPackage.getModulePath(m)))
+      .map(m => [ m, getModuleFile(tsPackage.getModulePath(m)) ]);
+  if (!moduleFiles.length) throw new PatchError(`No valid modules found to patch`);
 
   /* Determine files not already patched or outdated  */
   const patchableFiles = moduleFiles.filter(entry => {

--- a/projects/core/src/config.ts
+++ b/projects/core/src/config.ts
@@ -43,7 +43,7 @@ export const defaultNodePrinterOptions: ts.PrinterOptions = {
 // region: Patch Config
 /* ****************************************************************************************************************** */
 
-export const defaultInstallLibraries = [ 'tsc.js', 'typescript.js' ];
+export const defaultInstallLibraries = [ 'tsc.js', 'typescript.js', '_tsc.js' ];
 
 export const corePatchName = `<core>`;
 

--- a/projects/core/src/module/ts-module.ts
+++ b/projects/core/src/module/ts-module.ts
@@ -12,7 +12,14 @@ import { cachedFilePatchedPrefix } from '../config';
 /* ****************************************************************************************************************** */
 
 export namespace TsModule {
-  export const names = <const>['tsc.js', 'tsserverlibrary.js', 'typescript.js', 'tsserver.js'];
+  export const names = <const>[
+    'tsc.js', 
+    'tsserverlibrary.js', 
+    'typescript.js', 
+    'tsserver.js', 
+    '_tsc.js', 
+    '_tsserver.js',
+  ];
 }
 
 // endregion

--- a/projects/patch/src/ts/create-program.ts
+++ b/projects/patch/src/ts/create-program.ts
@@ -93,7 +93,7 @@ namespace tsp {
     const pluginCreator = new PluginCreator(plugins, { resolveBaseDir: projectConfig.projectDir ?? process.cwd() });
 
     /* Handle JSDoc parsing in v5.3+ */
-    if (tsp.currentLibrary === 'tsc' && tsShim.JSDocParsingMode && pluginCreator.needsTscJsDocParsing) {
+    if ((tsp.currentLibrary === 'tsc' || tsp.currentLibrary === '_tsc') && tsShim.JSDocParsingMode && pluginCreator.needsTscJsDocParsing) {
       host!.jsDocParsingMode = tsShim.JSDocParsingMode.ParseAll;
     }
 


### PR DESCRIPTION
@nonara I've checked that this PR is working on the `ts-patch install` command.

It works on both TypeScript 5.6 and 5.7 versions.

However, I have not implemented about the `tspc` case, because I don't know how to.

Here is the repo I've tested the `ts-patch install` command.

https://github.com/samchon/ts-patch-typescript-5.7